### PR TITLE
fix end_date property on Task

### DIFF
--- a/xerparser/model/classes/task.py
+++ b/xerparser/model/classes/task.py
@@ -231,7 +231,7 @@ class Task:
         if self.act_end_date:
             return self.act_end_date
         else:
-            return self.target_start_date
+            return self.target_end_date
 
     def __repr__(self):
         return self.task_code


### PR DESCRIPTION
end_date on Task returns target_end_date instead of of target_start_date if act_end_date is not available

fixes https://github.com/HassanEmam/PyP6Xer/issues/2