### PR TITLE
Allowed Reading of Files with unknown Characters and provided access to resource object

### DIFF
--- a/xerparser/model/activitiyresources.py
+++ b/xerparser/model/activitiyresources.py
@@ -23,7 +23,7 @@ class ActivityResources:
         obj = list(filter(lambda x: x.task_id == id and x.rsrc_id, cls._taskrsrc))
         obj1 = [{Resource.find_by_id(x.rsrc_id): {"BL_QTY":x.target_qty, "ACT_QTY": x.act_reg_qty,\
                                                   "REM_QTY": x.remain_qty}} for x in obj]
-        return obj1
+        return obj
 
     @property
     def count(self):

--- a/xerparser/model/classes/taskrsrc.py
+++ b/xerparser/model/classes/taskrsrc.py
@@ -1,3 +1,4 @@
+from xerparser.model.resources import Resources
 class TaskRsrc:
     taskrsrc_id = None
     task_id = None
@@ -98,6 +99,9 @@ class TaskRsrc:
 
     def get_id(self):
         return self.taskrsrc_id
+    @property
+    def resource(self):
+        return Resources.get_resource_by_id(self.rsrc_id)
 
     @staticmethod
     def find_by_id(code_id, activity_code_dict):

--- a/xerparser/reader.py
+++ b/xerparser/reader.py
@@ -5,6 +5,7 @@ This file starts the process of reading and parsing xer files
 import csv
 import mmap
 from tqdm import tqdm
+import codecs
 
 from xerparser import *
 
@@ -237,7 +238,7 @@ class Reader:
         self._activityresources = ActivityResources()
         self._udftypes = UDFTypes()
         self._udfvalues = UDFValues()
-        with open(filename) as tsvfile:
+        with codecs.open(filename, encoding='utf-8', errors='ignore') as tsvfile:
             stream = csv.reader(tsvfile, delimiter='\t')
             for row in tqdm(stream, total=self.get_num_lines(filename)):
                 if row[0] =="%T":


### PR DESCRIPTION
When the exported xer contains POBS entry, it contains hex character which crashes the reader due to charmap exception.
Using codecs library allows ignoring the errors 
https://github.com/HassanEmam/PyP6Xer/issues/5

Modified both activityresources and taskrsrc to allow access the taskresource object and the resource object consecutively
https://github.com/HassanEmam/PyP6Xer/issues/3